### PR TITLE
feat: include STS endpoint

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,5 +24,6 @@ provider "aws" {
   endpoints {
     lambda = "http://localhost:4566"
     iam    = "http://localhost:4566"
+    sts    = "http://localhost:4566"
   }
 }


### PR DESCRIPTION
An earlier candidate ran into an issue where `terraform` was trying to make STS requests to the real AWS.